### PR TITLE
new combination/application scheme

### DIFF
--- a/src/ATINEH.jl
+++ b/src/ATINEH.jl
@@ -2,7 +2,7 @@ __precompile__()
 module ATINEH
 
     include("AffineTransforms.jl")
-    include("IndexMaps.jl")
+    include("IndexingModifiers.jl")
     include("ExteriorHandling.jl")
     include("Interpolation.jl")
     include("IndexAffineTransform.jl")

--- a/src/AffineTransforms.jl
+++ b/src/AffineTransforms.jl
@@ -97,10 +97,10 @@ end
 @inline translate{N, T<:Real}(s::NTuple{N, T}) = AffineTransform{N}(eye(SMatrix{N,N, T}), SVector{N}(s))
 @inline translate{N, T<:NTuple{N, Real}}(s::T) = translate(promote(s...))
 
-function scale{N}(s::Vararg{Range, N})
+@inline function scale{N}(s::Vararg{Range, N})
     AffineTransform(SMatrix{N,N}(diagm(map(step, [s...]))), SVector{N}(map(is -> first(is)-step(is), [s...])))
 end
 
-function unscale{N}(s::Vararg{Range, N})
+@inline function unscale{N}(s::Vararg{Range, N})
     AffineTransform(SMatrix{N,N}(diagm(map(inv ∘ step, [s...]))), SVector{N}(map(is -> -first(is)/step(is)+1, [s...])))
 end

--- a/src/AffineTransforms.jl
+++ b/src/AffineTransforms.jl
@@ -48,7 +48,7 @@ function inv(A::AffineTransform)
 end
 
 @inline function (*){N}(A::AffineTransform{N}, B::AffineTransform{N})
-    AffineTransform{N}(A.matrix*B.matrix, A.shift+A.matrix*B.shift)
+    AffineTransform(A.matrix*B.matrix, A.shift+A.matrix*B.shift)
 end
 
 @inline function (*)(A::AffineTransform, v::AbstractVector)

--- a/src/AffineTransforms.jl
+++ b/src/AffineTransforms.jl
@@ -1,7 +1,7 @@
 using StaticArrays
 using Base.Cartesian
 
-export AffineTransform, axisrotate, rotate, translate, scale, unscale
+export AffineTransform, axisrotate, rotate, translate, scale, unscale, SMatrix, SVector
 
 import Base: size, eltype, show
 

--- a/src/ExteriorHandling.jl
+++ b/src/ExteriorHandling.jl
@@ -2,23 +2,31 @@ import Base: getindex, setindex!
 
 export ConstantExterior
 
+
+"conversion for numerical element types with special rule for Tuple{...} types"
+@inline elconvert{T}(::Type{T}, x) = T(x)
+
+@generated function elconvert{T<:Tuple}(::Type{T}, x)
+    Expr(:block, Expr(:meta, :inline), Expr(:tuple, (:($t(x)) for t in T.types)...))
+end
+
 struct ConstantExterior{T} <: AbstractIndexMap
     value::T
     ConstantExterior(value::T=0) where {T} = new{T}(value)
     ConstantExterior{T}() where {T} = new{T}(zero(T))
 end
 
-@inline function getindex{T}(A::AbstractArray{T}, ce::ConstantExterior, idx::Vararg{<:Number})
-    @boundscheck if !checkbounds(Bool, A, map(floor, idx)...); return T(ce.value); end
-    @inbounds return getindex(A, idx...)
+@inline function getindex{T}(A::MappedArray{T, N, A, <:ConstantExterior} where {N,A}, idx::Vararg{<:Number})
+    @boundscheck if !checkbounds(Bool, A, map(floor, idx)...); return T(A.m.value); end
+    @inbounds return getindex(A.a, idx...)
 end
 
-@inline function setindex!{T}(A::AbstractArray{T}, val, ce::ConstantExterior, idx::Vararg{<:Number})
+@inline function setindex!{T}(A::MappedArray{T, N, A, <:ConstantExterior} where {N,A}, val, idx::Vararg{<:Number})
     @boundscheck if !checkbounds(Bool, A, map(floor, idx)...); return end
-    @inbounds setindex!(A, val, idx...)
+    @inbounds setindex!(A.a, val, idx...)
 end
 
-@inline function addindex!{T}(A::AbstractArray{T}, val, ce::ConstantExterior, idx::Vararg{<:Number})
+@inline function addindex!{T}(A::MappedArray{T, N, A, <:ConstantExterior} where {N,A}, val, idx::Vararg{<:Number})
     @boundscheck if !checkbounds(Bool, A, map(floor, idx)...); return end
-    @inbounds addindex!(A, val, idx...)
+    @inbounds addindex!(A.a, val, idx...)
 end

--- a/src/ExteriorHandling.jl
+++ b/src/ExteriorHandling.jl
@@ -17,7 +17,7 @@ struct ConstantExterior{T} <: AbstractIndexingModifier
 end
 
 @inline function getindex{T}(A::MappedArray{T, N, A, <:ConstantExterior} where {N,A}, idx::Vararg{<:Number})
-    if checkbounds(Bool, A, map(floor, idx)...)
+    if checkbounds(Bool, A, idx...)
         @inbounds re = getindex(A.a, idx...)
         re
     else
@@ -26,13 +26,13 @@ end
 end
 
 @inline function setindex!{T}(A::MappedArray{T, N, A, <:ConstantExterior} where {N,A}, val, idx::Vararg{<:Number})
-    if checkbounds(Bool, A, map(floor, idx)...)
+    if checkbounds(Bool, A, idx...)
         @inbounds setindex!(A.a, val, idx...)
     end
 end
 
 @inline function addindex!{T}(A::MappedArray{T, N, A, <:ConstantExterior} where {N,A}, val, idx::Vararg{<:Number})
-    if checkbounds(Bool, A, map(floor, idx)...)
+    if checkbounds(Bool, A, idx...)
         @inbounds addindex!(A.a, val, idx...)
     end
 end

--- a/src/ExteriorHandling.jl
+++ b/src/ExteriorHandling.jl
@@ -10,7 +10,7 @@ export ConstantExterior, InBounds
     Expr(:block, Expr(:meta, :inline), Expr(:tuple, (:($t(x)) for t in T.types)...))
 end
 
-struct ConstantExterior{T} <: AbstractIndexMap
+struct ConstantExterior{T} <: AbstractIndexingModifier
     value::T
     ConstantExterior(value::T=0) where {T} = new{T}(value)
     ConstantExterior{T}() where {T} = new{T}(zero(T))
@@ -37,7 +37,7 @@ end
     end
 end
 
-struct InBounds <: AbstractIndexMap end
+struct InBounds <: AbstractIndexingModifier end
 
 @inline function getindex{T}(A::MappedArray{T, N, A, <:InBounds} where {N,A}, idx::Vararg{<:Number})
     @inbounds getindex(A.a, idx...)

--- a/src/IndexAffineTransform.jl
+++ b/src/IndexAffineTransform.jl
@@ -3,7 +3,7 @@ import ATINEH: addindex!
 
 export IndexAffineTransform
 
-struct IndexAffineTransform{AT<:AffineTransform} <: AbstractIndexMap
+struct IndexAffineTransform{AT<:AffineTransform} <: AbstractIndexingModifier
     at::AT
 end
 

--- a/src/IndexAffineTransform.jl
+++ b/src/IndexAffineTransform.jl
@@ -7,14 +7,14 @@ struct IndexAffineTransform{AT<:AffineTransform} <: AbstractIndexMap
     at::AT
 end
 
-@inline function getindex(A::AbstractArray, iat::IndexAffineTransform, idx::Vararg{<:Number})
-    getindex(A, (iat.at*idx)...)
+@inline function getindex(A::MappedArray_byMap{<:IndexAffineTransform}, idx::Vararg{<:Number})
+    getindex(A.a, (A.m.at*idx)...)
 end
 
-@inline function setindex!(A::AbstractArray, val, iat::IndexAffineTransform, idx::Vararg{<:Number})
-    setindex!(A, val, (iat.at*idx)...)
+@inline function setindex!(A::MappedArray_byMap{<:IndexAffineTransform}, val, idx::Vararg{<:Number})
+    setindex!(A.a, val, (A.m.at*idx)...)
 end
 
-@inline function addindex!(A::AbstractArray, val, iat::IndexAffineTransform, idx::Vararg{<:Number})
-    addindex!(A, val, (iat.at*idx)...)
+@inline function addindex!(A::MappedArray_byMap{<:IndexAffineTransform}, val, idx::Vararg{<:Number})
+    addindex!(A.a, val, (A.m.at*idx)...)
 end

--- a/src/IndexMaps.jl
+++ b/src/IndexMaps.jl
@@ -5,7 +5,7 @@ export AbstractIndexMap, MappedArray, MappedArray_byMap, IndexMapChain, IndexIde
 
 IndexTypes = Union{Number, Tuple, AffineTransform}
 
-addindex!(A::AbstractArray, value, i...) = A[i...] += value
+@inline addindex!(A::AbstractArray, value, i...) = begin @boundscheck checkbounds(A, i...); @inbounds A[i...] += value end
 
 "abstract index map"
 abstract type AbstractIndexMap end
@@ -71,10 +71,10 @@ PermuteIndices(P::Vararg{Int}) = PermuteIndices{P}()
     :($(Expr(:meta, :inline)); getindex(A.a, $([:(x[$i]) for i in P]...)))
 end
 
-@inline @generated function setindex!{P}(A::MappedArray_byMap{PermuteIndices{P}}, x::Vararg{<:IndexTypes})
-    :($(Expr(:meta, :inline)); getindex(A.a, val, $([:(x[$i]) for i in P]...)))
+@inline @generated function setindex!{P}(A::MappedArray_byMap{PermuteIndices{P}}, val, x::Vararg{<:IndexTypes})
+    :($(Expr(:meta, :inline)); setindex!(A.a, val, $([:(x[$i]) for i in P]...)))
 end
 
-@inline @generated function addindex!{P}(A::MappedArray_byMap{PermuteIndices{P}}, x::Vararg{<:IndexTypes})
-    :($(Expr(:meta, :inline)); getindex(A.a, val, $([:(x[$i]) for i in P]...)))
+@inline @generated function addindex!{P}(A::MappedArray_byMap{PermuteIndices{P}}, val, x::Vararg{<:IndexTypes})
+    :($(Expr(:meta, :inline)); addindex!(A.a, val, $([:(x[$i]) for i in P]...)))
 end

--- a/src/IndexMaps.jl
+++ b/src/IndexMaps.jl
@@ -1,61 +1,58 @@
 import Base: convert, (∘), getindex, setindex!, first, tail
 
 export addindex!
-export AbstractIndexMap, IndexMappedArray, IndexMapChain, IndexIdentity, PermuteIndices
+export AbstractIndexMap, MappedArray, MappedArray_byMap, IndexMapChain, IndexIdentity, PermuteIndices
 
-init(x) = reverse(tail(reverse(x)))
+IndexTypes = Union{Number, Tuple, AffineTransform}
 
-addindex!(A::AbstractArray, value, i::Vararg{Number}) = A[i...] += value
+addindex!(A::AbstractArray, value, i...) = A[i...] += value
 
 "abstract index map"
 abstract type AbstractIndexMap end
 
 "an array annotated with an index map"
-struct IndexMappedArray{T, N, A<:AbstractArray, I<:AbstractIndexMap} <: AbstractArray{T,N}
+struct MappedArray{T, N, A<:AbstractArray, M<:AbstractIndexMap} <: AbstractArray{T,N}
     a::A
-    i::I
-    IndexMappedArray(a::A, i::I) where {T, N, A<:AbstractArray{T,N}, I<:AbstractIndexMap} = new{T,N,A,I}(a,i)
-    IndexMappedArray{T, N}(a::A, i::I) where {T, N, A<:AbstractArray, I<:AbstractIndexMap} = new{T,N,A,I}(a,i)
+    m::M
+    MappedArray(a::A, m::M) where {T, N, A<:AbstractArray{T,N}, M<:AbstractIndexMap} = new{T,N,A,M}(a,m)
+    MappedArray{T, N}(a::A, m::M) where {T, N, A<:AbstractArray, M<:AbstractIndexMap} = new{T,N,A,M}(a,m)
 end
+MappedArray_byMap{I} = MappedArray{T,N,A,I} where {T, N, A}
 
-@inline getindex(A::AbstractArray, m::AbstractIndexMap, x...) = getindex(IndexMappedArray(A, m), x...)
-@inline getindex(A::IndexMappedArray, x::Vararg{Number}) = getindex(A.a, A.i, x...)
+@inline size(ma::MappedArray) = size(ma.a)
 
-@inline setindex!(A::AbstractArray, val,  m::AbstractIndexMap, x...) = setindex!(IndexMappedArray(A, m), val, x...)
-@inline setindex!(A::IndexMappedArray, val, x::Vararg{Number}) = setindex!(A.a, val, A.i, x...)
-
-@inline addindex!(A::AbstractArray, val,  m::AbstractIndexMap, x...) = addindex!(IndexMappedArray(A, m), val, x...)
-@inline addindex!(ima::IndexMappedArray, val, x::Vararg{Number}) = addindex!(ima.a, val, ima.i, x...)
+@inline getindex(A::AbstractArray, m::AbstractIndexMap, x::Vararg) = getindex(MappedArray(A, m), x...)
+@inline setindex!(A::AbstractArray, val,  m::AbstractIndexMap, x::Vararg) = setindex!(MappedArray(A, m), val, x...)
+@inline addindex!(A::AbstractArray, val,  m::AbstractIndexMap, x::Vararg) = addindex!(MappedArray(A, m), val, x...)
 
 "chain of index maps"
 struct IndexMapChain{T<:Tuple{Vararg{<: AbstractIndexMap}}} <: AbstractIndexMap
-    transforms::T
+    maps::T
 end
 
 IndexMapChain(x...) = IndexMapChain(x)
 
 @inline (∘)(A::AbstractIndexMap, B::AbstractIndexMap) = IndexMapChain(A, B)
-@inline (∘)(A::IndexMapChain, B::AbstractIndexMap) = IndexMapChain(A.transforms..., B)
-@inline (∘)(A::AbstractIndexMap, B::IndexMapChain) = IndexMapChain(A, B.transforms...)
-@inline (∘)(A::IndexMapChain, B::IndexMapChain) = IndexMapChain(A.transforms..., B.transforms...)
+@inline (∘)(A::IndexMapChain, B::AbstractIndexMap) = IndexMapChain(A.maps..., B)
+@inline (∘)(A::AbstractIndexMap, B::IndexMapChain) = IndexMapChain(A, B.maps...)
+@inline (∘)(A::IndexMapChain, B::IndexMapChain) = IndexMapChain(A.maps..., B.maps...)
 
-@inline getindex(A::AbstractArray, imc::IndexMapChain{Tuple{}}, x::Vararg{Number}) = getindex(A, x...)
-@inline getindex(A::AbstractArray, imc::IndexMapChain, x::Vararg{Number}) = getindex(IndexMappedArray(A, IndexMapChain(init(imc.transforms))), x...)
+@inline getindex(A::AbstractArray, imc::IndexMapChain{Tuple{}}, x::Vararg) = getindex(A, x...)
+@inline getindex(A::AbstractArray, imc::IndexMapChain, x::Vararg) = getindex(MappedArray(A, first(imc.maps)), IndexMapChain(tail(imc.maps)), x...)
 
-@inline setindex!(A::AbstractArray, val, imc::IndexMapChain{Tuple{}}, x::Vararg{Number}) = setindex!(A, val, x...)
-@inline setindex!(A::AbstractArray, val, imc::IndexMapChain, x::Vararg{Number}) = setindex!(IndexMappedArray(A, IndexMapChain(init(imc.transforms))), val, last(imc.transforms), x...)
+@inline setindex!(A::AbstractArray, val, imc::IndexMapChain{Tuple{}}, x::Vararg) = setindex!(A, val, x...)
+@inline setindex!(A::AbstractArray, val, imc::IndexMapChain, x::Vararg) = setindex!(MappedArray(A, first(imc.maps)), val, IndexMapChain(tail(imc.maps)), x...)
 
-@inline addindex!(A::AbstractArray, val, imc::IndexMapChain{Tuple{}}, x::Vararg{Number}) = addindex!(A, val, x...)
-@inline addindex!(A::AbstractArray, val, imc::IndexMapChain, x::Vararg{Number}) = addindex!(IndexMappedArray(A, IndexMapChain(init(imc.transforms))), val, last(imc.transforms), x...)
+@inline addindex!(A::AbstractArray, val, imc::IndexMapChain{Tuple{}}, x::Vararg) = addindex!(A, val, x...)
+@inline addindex!(A::AbstractArray, val, imc::IndexMapChain, x::Vararg) = addindex!(MappedArray(A, first(imc.maps)), val, IndexMapChain(tail(imc.maps)), x...)
 
 "index map without effect"
 struct IndexIdentity <: AbstractIndexMap end
 
-@inline getindex(A::AbstractArray, ::IndexIdentity, x::Vararg{Number}) = getindex(A, x...)
+@inline getindex(A::MappedArray_byMap{IndexIdentity}, x::Vararg{<:IndexTypes}) = getindex(A.a, x...)
+@inline setindex!(A::MappedArray_byMap{IndexIdentity}, val, x::Vararg{<:IndexTypes}) = setindex!(A.a, val, x...)
+@inline addindex!(A::MappedArray_byMap{IndexIdentity}, val, x::Vararg{<:IndexTypes}) = addindex!(A.a, val, x...)
 
-@inline setindex!(A::AbstractArray, val, ::IndexIdentity, x::Vararg{Number}) = setindex!(A, val, x...)
-
-@inline addindex!(A::AbstractArray, val, ::IndexIdentity, x::Vararg{Number}) = addindex!(A, val, x...)
 
 """
     struct PermuteIndices{P} <: AbstractIndexMap
@@ -70,14 +67,14 @@ end
 
 PermuteIndices(P::Vararg{Int}) = PermuteIndices{P}()
 
-@inline @generated function getindex{P}(A::AbstractArray, p::PermuteIndices{P}, x::Vararg{Number})
-    :($(Expr(:meta, :inline)); getindex(A, $([:(x[$i]) for i in P]...)))
+@inline @generated function getindex{P}(A::MappedArray_byMap{PermuteIndices{P}}, x::Vararg{<:IndexTypes})
+    :($(Expr(:meta, :inline)); getindex(A.a, $([:(x[$i]) for i in P]...)))
 end
 
-@inline @generated function setindex!{P}(A::AbstractArray, val, p::PermuteIndices{P}, x::Vararg{Number})
-    :($(Expr(:meta, :inline)); getindex(A, val, $([:(x[$i]) for i in P]...)))
+@inline @generated function setindex!{P}(A::MappedArray_byMap{PermuteIndices{P}}, x::Vararg{<:IndexTypes})
+    :($(Expr(:meta, :inline)); getindex(A.a, val, $([:(x[$i]) for i in P]...)))
 end
 
-@inline @generated function addindex!{P}(A::AbstractArray, val, p::PermuteIndices{P}, x::Vararg{Number})
-    :($(Expr(:meta, :inline)); getindex(A, val, $([:(x[$i]) for i in P]...)))
+@inline @generated function addindex!{P}(A::MappedArray_byMap{PermuteIndices{P}}, x::Vararg{<:IndexTypes})
+    :($(Expr(:meta, :inline)); getindex(A.a, val, $([:(x[$i]) for i in P]...)))
 end

--- a/src/IndexingModifiers.jl
+++ b/src/IndexingModifiers.jl
@@ -1,40 +1,40 @@
 import Base: convert, (∘), getindex, setindex!, first, tail
 
 export addindex!
-export AbstractIndexMap, MappedArray, MappedArray_byMap, IndexMapChain, IndexIdentity, PermuteIndices
+export AbstractIndexingModifier, MappedArray, MappedArray_byMap, IndexMapChain, IndexIdentity, PermuteIndices
 
 IndexTypes = Union{Number, Tuple, AffineTransform}
 
 @inline addindex!(A::AbstractArray, value, i...) = begin @boundscheck checkbounds(A, i...); @inbounds A[i...] += value end
 
 "abstract index map"
-abstract type AbstractIndexMap end
+abstract type AbstractIndexingModifier end
 
 "an array annotated with an index map"
-struct MappedArray{T, N, A<:AbstractArray, M<:AbstractIndexMap} <: AbstractArray{T,N}
+struct MappedArray{T, N, A<:AbstractArray, M<:AbstractIndexingModifier} <: AbstractArray{T,N}
     a::A
     m::M
-    MappedArray(a::A, m::M) where {T, N, A<:AbstractArray{T,N}, M<:AbstractIndexMap} = new{T,N,A,M}(a,m)
-    MappedArray{T, N}(a::A, m::M) where {T, N, A<:AbstractArray, M<:AbstractIndexMap} = new{T,N,A,M}(a,m)
+    MappedArray(a::A, m::M) where {T, N, A<:AbstractArray{T,N}, M<:AbstractIndexingModifier} = new{T,N,A,M}(a,m)
+    MappedArray{T, N}(a::A, m::M) where {T, N, A<:AbstractArray, M<:AbstractIndexingModifier} = new{T,N,A,M}(a,m)
 end
 MappedArray_byMap{I} = MappedArray{T,N,A,I} where {T, N, A}
 
 @inline size(ma::MappedArray) = size(ma.a)
 
-@inline getindex(A::AbstractArray, m::AbstractIndexMap, x::Vararg) = getindex(MappedArray(A, m), x...)
-@inline setindex!(A::AbstractArray, val,  m::AbstractIndexMap, x::Vararg) = setindex!(MappedArray(A, m), val, x...)
-@inline addindex!(A::AbstractArray, val,  m::AbstractIndexMap, x::Vararg) = addindex!(MappedArray(A, m), val, x...)
+@inline getindex(A::AbstractArray, m::AbstractIndexingModifier, x::Vararg) = getindex(MappedArray(A, m), x...)
+@inline setindex!(A::AbstractArray, val,  m::AbstractIndexingModifier, x::Vararg) = setindex!(MappedArray(A, m), val, x...)
+@inline addindex!(A::AbstractArray, val,  m::AbstractIndexingModifier, x::Vararg) = addindex!(MappedArray(A, m), val, x...)
 
 "chain of index maps"
-struct IndexMapChain{T<:Tuple{Vararg{<: AbstractIndexMap}}} <: AbstractIndexMap
+struct IndexMapChain{T<:Tuple{Vararg{<: AbstractIndexingModifier}}} <: AbstractIndexingModifier
     maps::T
 end
 
 IndexMapChain(x...) = IndexMapChain(x)
 
-@inline (∘)(A::AbstractIndexMap, B::AbstractIndexMap) = IndexMapChain(A, B)
-@inline (∘)(A::IndexMapChain, B::AbstractIndexMap) = IndexMapChain(A.maps..., B)
-@inline (∘)(A::AbstractIndexMap, B::IndexMapChain) = IndexMapChain(A, B.maps...)
+@inline (∘)(A::AbstractIndexingModifier, B::AbstractIndexingModifier) = IndexMapChain(A, B)
+@inline (∘)(A::IndexMapChain, B::AbstractIndexingModifier) = IndexMapChain(A.maps..., B)
+@inline (∘)(A::AbstractIndexingModifier, B::IndexMapChain) = IndexMapChain(A, B.maps...)
 @inline (∘)(A::IndexMapChain, B::IndexMapChain) = IndexMapChain(A.maps..., B.maps...)
 
 @inline getindex(A::AbstractArray, imc::IndexMapChain{Tuple{}}, x::Vararg) = getindex(A, x...)
@@ -47,7 +47,7 @@ IndexMapChain(x...) = IndexMapChain(x)
 @inline addindex!(A::AbstractArray, val, imc::IndexMapChain, x::Vararg) = addindex!(MappedArray(A, first(imc.maps)), val, IndexMapChain(tail(imc.maps)), x...)
 
 "index map without effect"
-struct IndexIdentity <: AbstractIndexMap end
+struct IndexIdentity <: AbstractIndexingModifier end
 
 @inline getindex(A::MappedArray_byMap{IndexIdentity}, x::Vararg{<:IndexTypes}) = getindex(A.a, x...)
 @inline setindex!(A::MappedArray_byMap{IndexIdentity}, val, x::Vararg{<:IndexTypes}) = setindex!(A.a, val, x...)
@@ -55,12 +55,12 @@ struct IndexIdentity <: AbstractIndexMap end
 
 
 """
-    struct PermuteIndices{P} <: AbstractIndexMap
+    struct PermuteIndices{P} <: AbstractIndexingModifier
     P is a tuple of ints permuting (or dropping or repeating) indices
     PermuteIndices{P}() where P = new{P}()
     PermuteIndices(::Type{Val{P}}) where P = new{P}()
 """
-struct PermuteIndices{P} <: AbstractIndexMap
+struct PermuteIndices{P} <: AbstractIndexingModifier
     PermuteIndices{P}() where P = new{P}()
     PermuteIndices(::Type{Val{P}}) where P = new{P}()
 end

--- a/src/Interpolations/LinearInterpolation.jl
+++ b/src/Interpolations/LinearInterpolation.jl
@@ -3,7 +3,7 @@ import ATINEH:addindex!
 
 export LinearInterpolation
 
-struct LinearInterpolation <: AbstractIndexMap
+struct LinearInterpolation <: AbstractIndexingModifier
 end
 
 @inline getindex(A::MappedArray_byMap{<:LinearInterpolation}, I::Vararg{<:Number}) = getindex(A, I)

--- a/src/Interpolations/LinearInterpolation.jl
+++ b/src/Interpolations/LinearInterpolation.jl
@@ -6,16 +6,16 @@ export LinearInterpolation
 struct LinearInterpolation <: AbstractIndexMap
 end
 
-@inline getindex(A::MappedArray_byMap{<:LinearInterpolation}, I::Vararg{Number}) = getindex(A, I)
+@inline getindex(A::MappedArray_byMap{<:LinearInterpolation}, I::Vararg{<:Number}) = getindex(A, I)
 @generated function getindex{N, IT<:NTuple{N, Number}}(A::MappedArray_byMap{<:LinearInterpolation}, I::IT)
     xs = ((Symbol("x_",i) for i in 1:N)...)
     ex = :(getindex(A.a, $(xs...)))
     preexs = Expr[]
 
     for i in 1:N
-        x_, i_, r_ = xs[i], Symbol("i_",i), Symbol("r_",i)
+        x_, i_, r_, f_ = xs[i], Symbol("i_",i), Symbol("r_",i), Symbol("f_",i)
         if IT.parameters[i] <: AbstractFloat
-            push!(preexs, :($i_ = floor(Int, I[$i])), :($r_ = mod(I[$i], 1)))
+            push!(preexs, :($f_ = floor(I[$i])), :($i_ = unsafe_trunc(Int, $f_)), :($r_ = I[$i]-$f_))
 
             ex = quote
                 +(let $x_ = $i_; (1-$r_)*$ex; end,
@@ -30,27 +30,26 @@ end
 
     quote
         $(Expr(:meta, :inline))
-        let $(preexs...)
-            $ex
-        end
+        $(preexs...)
+        $ex
     end
 end
 
 
-@generated function setindex!{N}(A::MappedArray_byMap{<:LinearInterpolation}, val, I::Vararg{Number,N})
+@generated function setindex!(A::MappedArray_byMap{<:LinearInterpolation}, val, I::Vararg{<:Number})
     throw(ArgumentError("setindex! is ill defined for linear interpolation"))
 end
 
-@inline addindex!(A::MappedArray_byMap{<:LinearInterpolation}, val, I::Vararg{Number}) = addindex!(A, val, I)
+@inline addindex!(A::MappedArray_byMap{<:LinearInterpolation}, val, I::Vararg{<:Number}) = addindex!(A, val, I)
 @generated function addindex!{N, IT<:NTuple{N, Number}}(A::MappedArray_byMap{<:LinearInterpolation}, val, I::IT)
     xs = ((Symbol("x_",i) for i in 1:N)...)
     ex = :(addindex!(A.a, val, $(xs...)))
     preexs = Expr[]
 
     for i in 1:N
-        x_, i_, r_ = xs[i], Symbol("i_",i), Symbol("r_",i)
+        x_, i_, r_, f_ = xs[i], Symbol("i_",i), Symbol("r_",i), Symbol("f_",i)
         if IT.parameters[i] <: AbstractFloat
-            push!(preexs, :($i_ = floor(Int, I[$i])), :($r_ = mod(I[$i], 1)))
+            push!(preexs, :($f_ = floor(I[$i])), :($i_ = unsafe_trunc(Int, $f_)), :($r_ = I[$i]-$f_))
 
             ex = quote
                 let $x_ = $i_, val=val*(1-$r_);
@@ -69,9 +68,8 @@ end
 
     quote
         $(Expr(:meta, :inline))
-        let $(preexs...)
-            $ex
-        end
+        $(preexs...)
+        $ex
         nothing
     end
 end

--- a/src/Interpolations/LinearInterpolation.jl
+++ b/src/Interpolations/LinearInterpolation.jl
@@ -6,10 +6,10 @@ export LinearInterpolation
 struct LinearInterpolation <: AbstractIndexMap
 end
 
-@inline getindex(A::AbstractArray, li::LinearInterpolation, I::Vararg{Number}) = getindex(A, li, I)
-@generated function getindex{N, IT<:NTuple{N, Number}}(A::AbstractArray, ::LinearInterpolation, I::IT)
+@inline getindex(A::MappedArray_byMap{<:LinearInterpolation}, I::Vararg{Number}) = getindex(A, I)
+@generated function getindex{N, IT<:NTuple{N, Number}}(A::MappedArray_byMap{<:LinearInterpolation}, I::IT)
     xs = ((Symbol("x_",i) for i in 1:N)...)
-    ex = :(getindex(A, $(xs...)))
+    ex = :(getindex(A.a, $(xs...)))
     preexs = Expr[]
 
     for i in 1:N
@@ -37,14 +37,14 @@ end
 end
 
 
-@generated function setindex!{N}(A::AbstractArray, val, ::LinearInterpolation, I::Vararg{Number,N})
+@generated function setindex!{N}(A::MappedArray_byMap{<:LinearInterpolation}, val, I::Vararg{Number,N})
     throw(ArgumentError("setindex! is ill defined for linear interpolation"))
 end
 
-@inline addindex!(A::AbstractArray, val, li::LinearInterpolation, I::Vararg{Number}) = addindex!(A, val, li, I)
-@generated function addindex!{N, IT<:NTuple{N, Number}}(A::AbstractArray, val, ::LinearInterpolation, I::IT)
+@inline addindex!(A::MappedArray_byMap{<:LinearInterpolation}, val, I::Vararg{Number}) = addindex!(A, val, I)
+@generated function addindex!{N, IT<:NTuple{N, Number}}(A::MappedArray_byMap{<:LinearInterpolation}, val, I::IT)
     xs = ((Symbol("x_",i) for i in 1:N)...)
-    ex = :(addindex!(A, val, $(xs...)))
+    ex = :(addindex!(A.a, val, $(xs...)))
     preexs = Expr[]
 
     for i in 1:N

--- a/src/Interpolations/NearestInterpolation.jl
+++ b/src/Interpolations/NearestInterpolation.jl
@@ -11,14 +11,14 @@ struct NearestInterpolation{R<:RoundingMode} <: AbstractIndexMap
     NearestInterpolation(::R=RoundNearest) where {R<:RoundingMode} = new{R}()
 end
 
-@inline function getindex{R}(A::AbstractArray, ::NearestInterpolation{R}, I::Vararg{<:Number})
-    getindex(A, map(x -> round(Int, x, R()), I)...)
+@inline function getindex{R}(A::MappedArray_byMap{<:NearestInterpolation{R}}, I::Vararg{<:Number})
+    getindex(A.a, map(x -> round(Int, x, R()), I)...)
 end
 
-@inline function setindex!{R}(A::AbstractArray, val, ::NearestInterpolation{R}, I::Vararg{<:Number})
-    setindex!(A, val, map(x -> round(Int, x, R()), I)...)
+@inline function setindex!{R}(A::MappedArray_byMap{<:NearestInterpolation{R}}, val, I::Vararg{<:Number})
+    setindex!(A.a, val, map(x -> round(Int, x, R()), I)...)
 end
 
-@inline function addindex!{R}(A::AbstractArray, val, ::NearestInterpolation{R}, I::Vararg{<:Number})
-    addindex!(A, val, map(x -> round(Int, x, R()), I)...)
+@inline function addindex!{R}(A::MappedArray_byMap{<:NearestInterpolation{R}}, val, I::Vararg{<:Number})
+    addindex!(A.a, val, map(x -> round(Int, x, R()), I)...)
 end

--- a/src/Interpolations/NearestInterpolation.jl
+++ b/src/Interpolations/NearestInterpolation.jl
@@ -7,7 +7,7 @@ round(x::Real, ::RoundingMode{:Nearest}) = trunc(x)
 round{I<:Integer}(::Type{I}, x::Integer, ::RoundingMode) = I(x)
 
 
-struct NearestInterpolation{R<:RoundingMode} <: AbstractIndexMap
+struct NearestInterpolation{R<:RoundingMode} <: AbstractIndexingModifier
     NearestInterpolation(::R=RoundNearest) where {R<:RoundingMode} = new{R}()
 end
 

--- a/test/IndexMaps.jl
+++ b/test/IndexMaps.jl
@@ -1,10 +1,6 @@
 using Base.Test
 
 @testset "IndexTransform" begin
-    @testset "init" begin
-        @test ATINEH.init((1,2,3)) == (1,2)
-    end
-
    @testset "IndexIdentity" begin
         @test @inferred(IndexIdentity()) isa AbstractIndexMap
     end

--- a/test/IndexingModifiers.jl
+++ b/test/IndexingModifiers.jl
@@ -2,11 +2,11 @@ using Base.Test
 
 @testset "IndexTransform" begin
    @testset "IndexIdentity" begin
-        @test @inferred(IndexIdentity()) isa AbstractIndexMap
+        @test @inferred(IndexIdentity()) isa AbstractIndexingModifier
     end
 
     @testset "IndexMapChain" begin
-        @test @inferred(IndexMapChain()) isa AbstractIndexMap
+        @test @inferred(IndexMapChain()) isa AbstractIndexingModifier
         @test @inferred(IndexMapChain(IndexIdentity())) isa IndexMapChain{Tuple{IndexIdentity}}
         @test @inferred(IndexIdentity() ∘ IndexIdentity()) isa IndexMapChain
         @test @inferred(IndexIdentity() ∘ IndexIdentity() ∘ IndexIdentity()) isa IndexMapChain

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Base.Test
 
 @testset "runtests" begin
     include("AffineTransforms.jl")
-    include("IndexMaps.jl")
+    include("IndexingModifiers.jl")
     include("ExteriorHandling.jl")
     @testset "Interpolations" begin
         include("Interpolations/LinearInterpolation.jl")


### PR DESCRIPTION
Wrapping all Modifiers into nested MappedArray instances and dispatch them from these wrapped objects allows a simpler scheme for their combination and application as well as more freedom in the modification in the array access (including changing the apparent element type and the shape while maintaining type stability)